### PR TITLE
feat: add validation for local modules plan only

### DIFF
--- a/module.go
+++ b/module.go
@@ -92,6 +92,15 @@ func (m *Module) Apply(t *testing.T) error {
 	return nil
 }
 
+// Plan validates a Terraform module without applying changes
+func (m *Module) Plan() error {
+	_, err := terraform.InitAndPlanE(nil, m.Options)
+	if err != nil {
+		return fmt.Errorf("terraform plan failed for module %s: %w", m.Name, err)
+	}
+	return nil
+}
+
 // Destroy tears down a deployed Terraform module
 func (m *Module) Destroy(t *testing.T) error {
 	t.Helper()


### PR DESCRIPTION
## Description

This PR uses the same local module validation but it performs a validate only now... so this can be used in called workflows as a required check

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)