### PR TITLE
fix: prevent submodule regex from matching modules outside current repository

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -33,8 +33,10 @@ func (c *DefaultSourceConverter) ConvertToLocal(ctx context.Context, modulePath 
 	}
 
 	moduleSource := fmt.Sprintf("%s/%s/%s", moduleInfo.Namespace, moduleInfo.Name, moduleInfo.Provider)
-	submodulePattern := fmt.Sprintf(`^%s/([^/]+)/%s//modules/(.*)$`,
-		regexp.QuoteMeta(moduleInfo.Namespace), regexp.QuoteMeta(moduleInfo.Provider))
+	submodulePattern := fmt.Sprintf(`^%s/%s/%s//modules/(.*)$`,
+		regexp.QuoteMeta(moduleInfo.Namespace),
+		regexp.QuoteMeta(moduleInfo.Name),
+		regexp.QuoteMeta(moduleInfo.Provider))
 	submoduleRegex := regexp.MustCompile(submodulePattern)
 
 	for _, file := range files {
@@ -138,8 +140,8 @@ func (c *DefaultSourceConverter) updateModuleBlock(block *hclwrite.Block, module
 		block.Body().RemoveAttribute("version")
 		return true
 	case submoduleRegex != nil:
-		if matches := submoduleRegex.FindStringSubmatch(sourceValue); len(matches) == 3 {
-			localPath := fmt.Sprintf("../../modules/%s", strings.TrimPrefix(matches[2], "/"))
+		if matches := submoduleRegex.FindStringSubmatch(sourceValue); len(matches) == 2 {
+			localPath := fmt.Sprintf("../../modules/%s", strings.TrimPrefix(matches[1], "/"))
 			block.Body().SetAttributeValue("source", cty.StringVal(localPath))
 			block.Body().RemoveAttribute("version")
 			return true


### PR DESCRIPTION
## Description

This PR prevents submodules from another scope switching to local path while testing

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #69 